### PR TITLE
Replacing explode functions with preg_split

### DIFF
--- a/src/Codeception/Util/JsonType.php
+++ b/src/Codeception/Util/JsonType.php
@@ -117,14 +117,14 @@ class JsonType
                 }
                 continue;
             }
-            $matchTypes = explode('|', $type);
+            $matchTypes = preg_split("#(?![^]\(]*\))\|#", $type);
             $matched = false;
             $currentType = strtolower(gettype($data[$key]));
             if ($currentType == 'double') {
                 $currentType = 'float';
             }
             foreach ($matchTypes as $matchType) {
-                $filters = explode(':', $matchType);
+                $filters = preg_split("#(?![^]\(]*\))\:#", $matchType);
                 $expectedType = trim(strtolower(array_shift($filters)));
 
                 if ($expectedType != $currentType) {


### PR DESCRIPTION
Replacing "explode" function with "preg_split" alternatives allows to use all characters inside a regex pattern.